### PR TITLE
Fix Return value must be of type ?string

### DIFF
--- a/engine/google/classes/engine.php
+++ b/engine/google/classes/engine.php
@@ -135,6 +135,6 @@ class engine extends \tool_translate\engine {
                 return null;
             }
         }
-        return $return;
+        return $return['data']['translations'][0]['translatedText'];
     }
 }


### PR DESCRIPTION
Fix Google engine translatetext function return value (see issue #2 )